### PR TITLE
Use date to generate backdated commit timestamps

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Backdated commit 8 at 2025-06-10T06:40:00
 Backdated commit 9 at 2025-06-10T06:45:00
 Backdated commit 10 at 2025-06-10T06:50:00
 Backdated commit 11 at 2025-06-10T06:55:00
-Backdated commit 12 at 2025-06-10T06:60:00
+Backdated commit 12 at 2025-06-10T07:00:00
 Commit 1 at 2025-06-10T06:05:00
 Commit 2 at 2025-06-10T06:10:00
 Commit 3 at 2025-06-10T06:15:00
@@ -51,14 +51,14 @@ Commit 8 at 2025-06-10T06:40:00
 Commit 9 at 2025-06-10T06:45:00
 Commit 10 at 2025-06-10T06:50:00
 Commit 11 at 2025-06-10T06:55:00
-Commit 12 at 2025-06-10T06:60:00
-Fix-email Commit 1 at 2025-06-10T06:60:00
-Fix-email Commit 2 at 2025-06-10T06:60:00
-Fix-email Commit 3 at 2025-06-10T06:60:00
-Fix-email Commit 4 at 2025-06-10T06:60:00
-Fix-email Commit 5 at 2025-06-10T06:60:00
-Fix-email Commit 6 at 2025-06-10T06:60:00
-Fix-email Commit 7 at 2025-06-10T06:60:00
-Fix-email Commit 8 at 2025-06-10T06:60:00
-Fix-email Commit 9 at 2025-06-10T06:60:00
-Fix-email Commit 10 at 2025-06-10T06:60:00
+Commit 12 at 2025-06-10T07:00:00
+Fix-email Commit 1 at 2025-06-10T07:00:00
+Fix-email Commit 2 at 2025-06-10T07:00:00
+Fix-email Commit 3 at 2025-06-10T07:00:00
+Fix-email Commit 4 at 2025-06-10T07:00:00
+Fix-email Commit 5 at 2025-06-10T07:00:00
+Fix-email Commit 6 at 2025-06-10T07:00:00
+Fix-email Commit 7 at 2025-06-10T07:00:00
+Fix-email Commit 8 at 2025-06-10T07:00:00
+Fix-email Commit 9 at 2025-06-10T07:00:00
+Fix-email Commit 10 at 2025-06-10T07:00:00

--- a/create_backdated_commits.sh
+++ b/create_backdated_commits.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-for i in $(seq 0 11); do
+for i in $(seq 1 12); do
   ts=$(date -u -d "2025-06-10 06:00:00 UTC + $((i*5)) minutes" "+%Y-%m-%dT%H:%M:%S")
   echo "Backdated commit $i at $ts" >> README.md
   git add README.md

--- a/create_backdated_commits.sh
+++ b/create_backdated_commits.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 for i in $(seq 0 11); do
-  min=$(printf '%02d' $((i*5)))          # 00 05 10 … 55
-  ts="2025-06-10T06:${min}:00"
+  ts=$(date -u -d "2025-06-10 06:00:00 UTC + $((i*5)) minutes" "+%Y-%m-%dT%H:%M:%S")
   echo "Backdated commit $i at $ts" >> README.md
   git add README.md
   GIT_AUTHOR_DATE="$ts" GIT_COMMITTER_DATE="$ts" \


### PR DESCRIPTION
## Summary
- calculate commit timestamps via `date` with UTC to avoid invalid times
- update README examples to show corrected `07:00:00` timestamp instead of `06:60:00`

## Testing
- `bash create_backdated_commits.sh`


------
https://chatgpt.com/codex/tasks/task_e_68a03706dfc48328b89dd0fa018a7053