### PR TITLE
docs: remove README placeholders

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,64 +1,8 @@
 # Swartea_Zama
 
-用于参加 **Zama Developer Program** 的测试仓库。  
+用于参加 **Zama Developer Program** 的测试仓库。
 这里通过多次小提交（web edits）证明 GitHub 开发活动，供 Guild 验证。
 
 最近提交：参见 commit 历史。
-Backdated commit $i at $ts
-Backdated commit $i at $ts
-Backdated commit $i at $ts
-Backdated commit $i at $ts
-Backdated commit $i at $ts
-Backdated commit $i at $ts
-Backdated commit $i at $ts
-Backdated commit $i at $ts
-Backdated commit $i at $ts
-Backdated commit $i at $ts
-Backdated commit $i at $ts
-Backdated commit $i at $ts
-Backdated commit $i at $ts
-Backdated commit $i at $ts
-Backdated commit $i at $ts
-Backdated commit $i at $ts
-Backdated commit $i at $ts
-Backdated commit $i at $ts
-Backdated commit $i at $ts
-Backdated commit $i at $ts
-Backdated commit $i at $ts
-Backdated commit $i at $ts
-Backdated commit $i at $ts
-Backdated commit $i at $ts
-Backdated commit 1 at 2025-06-10T06:05:00
-Backdated commit 2 at 2025-06-10T06:10:00
-Backdated commit 3 at 2025-06-10T06:15:00
-Backdated commit 4 at 2025-06-10T06:20:00
-Backdated commit 5 at 2025-06-10T06:25:00
-Backdated commit 6 at 2025-06-10T06:30:00
-Backdated commit 7 at 2025-06-10T06:35:00
-Backdated commit 8 at 2025-06-10T06:40:00
-Backdated commit 9 at 2025-06-10T06:45:00
-Backdated commit 10 at 2025-06-10T06:50:00
-Backdated commit 11 at 2025-06-10T06:55:00
-Backdated commit 12 at 2025-06-10T06:60:00
-Commit 1 at 2025-06-10T06:05:00
-Commit 2 at 2025-06-10T06:10:00
-Commit 3 at 2025-06-10T06:15:00
-Commit 4 at 2025-06-10T06:20:00
-Commit 5 at 2025-06-10T06:25:00
-Commit 6 at 2025-06-10T06:30:00
-Commit 7 at 2025-06-10T06:35:00
-Commit 8 at 2025-06-10T06:40:00
-Commit 9 at 2025-06-10T06:45:00
-Commit 10 at 2025-06-10T06:50:00
-Commit 11 at 2025-06-10T06:55:00
-Commit 12 at 2025-06-10T06:60:00
-Fix-email Commit 1 at 2025-06-10T06:60:00
-Fix-email Commit 2 at 2025-06-10T06:60:00
-Fix-email Commit 3 at 2025-06-10T06:60:00
-Fix-email Commit 4 at 2025-06-10T06:60:00
-Fix-email Commit 5 at 2025-06-10T06:60:00
-Fix-email Commit 6 at 2025-06-10T06:60:00
-Fix-email Commit 7 at 2025-06-10T06:60:00
-Fix-email Commit 8 at 2025-06-10T06:60:00
-Fix-email Commit 9 at 2025-06-10T06:60:00
-Fix-email Commit 10 at 2025-06-10T06:60:00
+
+示例：Backdated commit 1 at 2025-06-10T06:05:00 —— 展示回溯提交格式。


### PR DESCRIPTION
## Summary
- remove placeholder commit entries from README
- add a single real example to demonstrate backdated commit format

## Testing
- `bash -n create_backdated_commits.sh`


------
https://chatgpt.com/codex/tasks/task_e_68a03708b2ac83288b4c0fd1426f4e3c